### PR TITLE
Add requests to install_requires in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests>=1.0.4

--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ setup(
     packages=[PACKAGE],
     zip_safe=False,
     long_description=open("README.md").read(),
+    install_requires=['requests>=1.0.4']
 )


### PR DESCRIPTION
Add the `requests` package to `install_requires` in `setup.py` so that it has a correct dependency on `requests` that doesn't require it to be installed manually.

Also set the version of requests to be 1.0.4 or newer